### PR TITLE
Added userapi db schema script that creates the db when you run the docker container

### DIFF
--- a/userApi/Dockerfile
+++ b/userApi/Dockerfile
@@ -1,0 +1,3 @@
+FROM openjdk:21-jdk-slim
+COPY build/libs/userApi.jar app.jar
+ENTRYPOINT [ "java" , "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005" , "-jar" , "app.jar" ]

--- a/userApi/compose.yaml
+++ b/userApi/compose.yaml
@@ -2,12 +2,12 @@ services:
   mysql:
     image: 'mysql:latest'
     environment:
-      - 'MYSQL_DATABASE=userdb'
+      - 'MYSQL_DATABASE=userapi'
       - 'MYSQL_ROOT_PASSWORD=verysecret'
       - 'MYSQL_PASSWORD=secret'
       - 'MYSQL_USER=user'
     ports:
-      - '3306'
+      - '3306:3306'
     volumes:
       - './src/main/resources:/docker-entrypoint-initdb.d'
     networks:

--- a/userApi/compose.yaml
+++ b/userApi/compose.yaml
@@ -2,9 +2,28 @@ services:
   mysql:
     image: 'mysql:latest'
     environment:
-      - 'MYSQL_DATABASE=mydatabase'
-      - 'MYSQL_PASSWORD=secret'
+      - 'MYSQL_DATABASE=userdb'
       - 'MYSQL_ROOT_PASSWORD=verysecret'
-      - 'MYSQL_USER=myuser'
+      - 'MYSQL_PASSWORD=secret'
+      - 'MYSQL_USER=user'
     ports:
       - '3306'
+    volumes:
+      - './src/main/resources:/docker-entrypoint-initdb.d'
+    networks:
+        - userapi-network
+
+  userapi:
+    build: .
+    image: 'userapi:latest'
+    container_name: 'userapi'
+    depends_on:
+      - mysql
+    networks:
+      - userapi-network
+    ports:
+      - '8080:8080'
+
+networks:
+    userapi-network:
+        driver: bridge

--- a/userApi/src/main/resources/application.properties
+++ b/userApi/src/main/resources/application.properties
@@ -1,2 +1,11 @@
 spring.application.name=Medium-Website
-spring.docker.compose.enabled=false
+spring.docker.compose.enabled=true
+
+spring.datasource.url=jdbc:mysql://localhost:3306/userapi
+spring.datasource.username=user
+spring.datasource.password=1234
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect

--- a/userApi/src/main/resources/application.properties
+++ b/userApi/src/main/resources/application.properties
@@ -3,7 +3,7 @@ spring.docker.compose.enabled=true
 
 spring.datasource.url=jdbc:mysql://localhost:3306/userapi
 spring.datasource.username=user
-spring.datasource.password=1234
+spring.datasource.password=secret
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update

--- a/userApi/src/main/resources/schema.sql
+++ b/userApi/src/main/resources/schema.sql
@@ -1,0 +1,34 @@
+CREATE DATABASE IF NOT EXISTS userapi;
+
+USE userapi;
+
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    role ENUM('USER', 'ADMIN') NOT NULL,
+    about TEXT,
+    profile_picture VARCHAR(255), -- URL to image
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS followers (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    follower_id INT NOT NULL,
+    following_id INT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (follower_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (following_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS admin_actions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    admin_id INT NOT NULL, -- Admin doing the action
+    user_id INT NOT NULL,  -- target
+    action ENUM('BAN', 'UNBAN') NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (admin_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
The mysql container searches for any .sql file in the resources folder and runs it on the initial setup of the container within the compose.yaml under volumes.

![image](https://github.com/user-attachments/assets/c5b378cb-4713-4b06-b2dd-18a9aca0f62d)

If your container is already initialized run:

`docker-compose down`

and then as I have `build: .` in our app container you can run:

`docker-compose up --build` 

which will update your image, build the containers and initialize the db using the schema.sql.