### PR TITLE
Create docker container to initialize contentApi db

### DIFF
--- a/contentApi/Dockerfile
+++ b/contentApi/Dockerfile
@@ -1,0 +1,3 @@
+FROM openjdk:21-jdk-slim
+COPY build/libs/contentApi.jar app.jar
+ENTRYPOINT [ "java" , "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005" , "-jar" , "app.jar" ]

--- a/contentApi/compose.yaml
+++ b/contentApi/compose.yaml
@@ -2,9 +2,28 @@ services:
   mysql:
     image: 'mysql:latest'
     environment:
-      - 'MYSQL_DATABASE=mydatabase'
-      - 'MYSQL_PASSWORD=secret'
+      - 'MYSQL_DATABASE=contentapi'
       - 'MYSQL_ROOT_PASSWORD=verysecret'
-      - 'MYSQL_USER=myuser'
+      - 'MYSQL_PASSWORD=secret'
+      - 'MYSQL_USER=user'
     ports:
-      - '3306'
+      - '3306:3306'
+    volumes:
+      - './src/main/resources:/docker-entrypoint-initdb.d'
+    networks:
+      - contentapi-network
+
+  contentapi:
+    build: .
+    image: 'contentapi:latest'
+    container_name: 'contentapi'
+    depends_on:
+      - mysql
+    networks:
+      - contentapi-network
+    ports:
+      - '8080:8080'
+
+networks:
+  contentapi-network:
+    driver: bridge

--- a/contentApi/src/main/resources/application.properties
+++ b/contentApi/src/main/resources/application.properties
@@ -1,2 +1,11 @@
 spring.application.name=Medium-Website
-spring.docker.compose.enabled=false
+spring.docker.compose.enabled=true
+
+spring.datasource.url=jdbc:mysql://localhost:3306/contentapi
+spring.datasource.username=user
+spring.datasource.password=secret
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect

--- a/contentApi/src/main/resources/schema.sql
+++ b/contentApi/src/main/resources/schema.sql
@@ -1,0 +1,29 @@
+CREATE DATABASE IF NOT EXISTS contentapi;
+
+USE contentapi;
+
+CREATE TABLE IF NOT EXISTS article (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL, -- article title
+    content TEXT NOT NULL, -- article content
+    author_id INT NOT NULL, -- would be user but can't reference user table in userApi
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS share (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    article_id INT NOT NULL,
+    platform ENUM('FACEBOOK', 'TWITTER') NOT NULL,
+    shared_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (article_id) REFERENCES article(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS comment (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    article_id INT NOT NULL,
+    user_id INT NOT NULL,
+    content TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (article_id) REFERENCES article(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
if containers are already initialized run:

`docker-compose down`

then when you run `docker-compose up --build` it will create the db.

Do this if you make any changes to the schema.
Also from what I have in this and userApi the schema will have to be refactored when we create more microservices
e.g. moving admin actions from userApi db to its own microservice for admin management